### PR TITLE
Fix code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/firstfile.py
+++ b/firstfile.py
@@ -54,7 +54,11 @@ def delete_user():
 @app.route('/file_upload', methods=['POST'])
 def file_upload():
     file = request.files['file']
-    file.save(os.path.join('/uploads', file.filename))
+    base_path = '/uploads'
+    fullpath = os.path.normpath(os.path.join(base_path, file.filename))
+    if not fullpath.startswith(base_path):
+        raise Exception("Invalid file path")
+    file.save(fullpath)
 
     return "File uploaded successfully!"
 


### PR DESCRIPTION
Fixes [https://github.com/IvoryMahiSingh/Test1/security/code-scanning/7](https://github.com/IvoryMahiSingh/Test1/security/code-scanning/7)

To fix the problem, we need to ensure that the file path constructed from user input is safe. This can be achieved by normalizing the path and ensuring it is contained within a designated safe directory. We will use `os.path.normpath` to normalize the path and then check if the resulting path starts with the intended base directory.

1. Normalize the path using `os.path.normpath`.
2. Check that the normalized path starts with the `/uploads` directory.
3. If the path is valid, proceed with saving the file; otherwise, raise an exception.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
